### PR TITLE
Make full binning more like TRI2

### DIFF
--- a/src/main/java/flimlib/flimj/ui/FLIMJCommand.java
+++ b/src/main/java/flimlib/flimj/ui/FLIMJCommand.java
@@ -66,7 +66,7 @@ public class FLIMJCommand implements Command {
 			EventQueue.invokeLater(() -> {
 				initSwing(fxPanel);
 			});
-		
+
 		if (!initSuccessful[0])
 			log().warn("FLIMJ: UI init failed or aborted by user. Exiting.");
 	}
@@ -114,7 +114,7 @@ public class FLIMJCommand implements Command {
 
 	/**
 	 * Initializes the GUI frame.
-	 * 
+	 *
 	 * @param fxPanel the embeded channel
 	 * @throws IOException if the fxml is not found
 	 * @return <code>true</code> - if the operation is successful
@@ -171,7 +171,7 @@ public class FLIMJCommand implements Command {
 
 	/**
 	 * Loads the icon image specified by url in different resolutions.
-	 * 
+	 *
 	 * @param url the URL of the icon image
 	 * @return the image in 16x16, 20x20, 32x32 and 40x40
 	 */

--- a/src/main/java/flimlib/flimj/ui/FitProcessor.java
+++ b/src/main/java/flimlib/flimj/ui/FitProcessor.java
@@ -250,14 +250,15 @@ public class FitProcessor {
 					origIntensity.dimension(axisOrder[1]));
 			allMask = true;
 		}
+
 		if (size != binRadius) {
 			// recalculate threshold to equalize per-pixel threshold
-			// params.iThresh = Math.round((double) params.iThresh //
-			// 		/ ((2 * binRadius + 1) * (2 * binRadius + 1))
-			// 		* ((2 * kernelSize + 1) * (2 * kernelSize + 1)));
+			params.iThresh = Math.round((double) params.iThresh //
+					/ ((2 * binRadius + 1) * (2 * binRadius + 1))
+					* ((2 * size + 1) * (2 * size + 1)));
 			// invalidate cached
 			binnedTrans = null;
-			binRadius = kernelSize;
+			binRadius = size;
 			if (size > 0) {
 				Img<DoubleType> kernel = FlimOps.makeSquareKernel(kernelSize * 2 + 1);
 				results.intensityMap = (Img<FloatType>) (allMask
@@ -267,6 +268,7 @@ public class FitProcessor {
 			} else
 				results.intensityMap = (Img<FloatType>) origIntensity;
 		}
+
 		// load trans after binning
 		setPreviewPos(previewX, previewY, false);
 	}

--- a/src/main/java/flimlib/flimj/ui/FitProcessor.java
+++ b/src/main/java/flimlib/flimj/ui/FitProcessor.java
@@ -243,22 +243,23 @@ public class FitProcessor {
 
 	public void setBinning(int size) {
 		allMask = false;
+		int kernelSize = size;
 		if (size == -1) {
 			// FIXME: divide by 2 after https://github.com/imagej/imagej-ops/issues/628 is fixed
-			size = (int) Math.max(origIntensity.dimension(axisOrder[0]),
+			kernelSize = (int) Math.max(origIntensity.dimension(axisOrder[0]),
 					origIntensity.dimension(axisOrder[1]));
 			allMask = true;
 		}
 		if (size != binRadius) {
 			// recalculate threshold to equalize per-pixel threshold
-			params.iThresh = Math.round((double) params.iThresh //
-					/ ((2 * binRadius + 1) * (2 * binRadius + 1))
-					* ((2 * size + 1) * (2 * size + 1)));
+			// params.iThresh = Math.round((double) params.iThresh //
+			// 		/ ((2 * binRadius + 1) * (2 * binRadius + 1))
+			// 		* ((2 * kernelSize + 1) * (2 * kernelSize + 1)));
 			// invalidate cached
 			binnedTrans = null;
-			binRadius = size;
+			binRadius = kernelSize;
 			if (size > 0) {
-				Img<DoubleType> kernel = FlimOps.makeSquareKernel(size * 2 + 1);
+				Img<DoubleType> kernel = FlimOps.makeSquareKernel(kernelSize * 2 + 1);
 				results.intensityMap = (Img<FloatType>) (allMask
 						? ops.filter().convolve(origIntensity, kernel,
 								new OutOfBoundsPeriodicFactory<>())
@@ -573,7 +574,7 @@ public class FitProcessor {
 
 	/**
 	 * Permute the coordinates from ltDimension-last to ltDimension-at-ltAxis.
-	 * 
+	 *
 	 * @param coordinates  the coordinates in ltDimension-last order
 	 * @param lifetimeAxis the index of the lifetime axis
 	 * @return the coordinates in ltDimension-at-ltAxis order
@@ -589,7 +590,7 @@ public class FitProcessor {
 
 	/**
 	 * Permute the coordinates from ltDimension-at-ltAxis to ltDimension-last.
-	 * 
+	 *
 	 * @param coordinates  the coordinates in ltDimension-at-ltAxis order
 	 * @param lifetimeAxis the index of the lifetime axis
 	 * @return the coordinates in ltDimension-last order

--- a/src/main/java/flimlib/flimj/ui/controller/PlotCtrl.java
+++ b/src/main/java/flimlib/flimj/ui/controller/PlotCtrl.java
@@ -229,7 +229,7 @@ public class PlotCtrl extends AbstractCtrl {
 
 	/**
 	 * Adds change listeners to critical values so that they work together.
-	 * 
+	 *
 	 * @param csr     the cursor
 	 * @param csrPos  the cursor position in [0, 1]
 	 * @param spinner the spinner associated with the cursor position
@@ -323,7 +323,7 @@ public class PlotCtrl extends AbstractCtrl {
 
 	/**
 	 * Retrieves the photon count within the interval [fitStart, fitEnd].
-	 * 
+	 *
 	 * @return the photon count
 	 */
 	private String getphtnCnt() {
@@ -337,7 +337,7 @@ public class PlotCtrl extends AbstractCtrl {
 
 	/**
 	 * Updates param in fit processors when indices are changed.
-	 * 
+	 *
 	 * @param isLCsr true if change is on left cursor (start)
 	 * @param newVal the updated value
 	 */
@@ -407,7 +407,7 @@ public class PlotCtrl extends AbstractCtrl {
 
 	/**
 	 * The one-liner for {@link #adjustPlottedPortion(boolean, Series, List, double, int)}
-	 * 
+	 *
 	 * @param isLCsr
 	 * @param plotIdx
 	 * @param csrPosValue
@@ -420,7 +420,7 @@ public class PlotCtrl extends AbstractCtrl {
 
 	/**
 	 * Adjusts the portion of the {@link Series} displayed according to the change of the cursor.
-	 * 
+	 *
 	 * @param isLCsr      {@code true} the cursor is {@link #lCsr}
 	 * @param series      the data series in question
 	 * @param dataList    the list of (x, y) data
@@ -472,7 +472,7 @@ public class PlotCtrl extends AbstractCtrl {
 
 	/**
 	 * Plots the fitted function as well as the transient data and residuals.
-	 * 
+	 *
 	 * @param trans the transient series
 	 * @param xInc  the x (time) increment
 	 */
@@ -567,7 +567,7 @@ public class PlotCtrl extends AbstractCtrl {
 
 	/**
 	 * Add a new data point to the chart.
-	 * 
+	 *
 	 * @param list the series data
 	 * @param idx  the index to insert into {@code list}
 	 * @param x    the x value

--- a/src/main/java/flimlib/flimj/ui/controller/SettingsCtrl.java
+++ b/src/main/java/flimlib/flimj/ui/controller/SettingsCtrl.java
@@ -94,6 +94,8 @@ public class SettingsCtrl extends AbstractCtrl {
 	/** The list of all input parameter indices */
 	private List<Integer> paramIndices;
 
+	private double threshBinZero;
+
 	/** The list of dataset present under the current context */
 	private HashMap<String, FitParams<FloatType>> presentDatasets;
 
@@ -113,6 +115,12 @@ public class SettingsCtrl extends AbstractCtrl {
 		iThreshSpinner.getNumberProperty().addListener((obs, oldVal, newVal) -> {
 			FitParams<FloatType> params = getParams();
 			params.iThresh = newVal.floatValue();
+
+			ObjectProperty<Double> binSizeProperty = binSizeSpinner.getNumberProperty();
+			if (binSizeProperty.get() == 0.0) {
+				threshBinZero = newVal.floatValue();
+			}
+
 			// recalculate global trans for pixels above threshold
 			fp.invalidateGlobalTrans();
 			// turn off estimate based on percentage
@@ -153,23 +161,24 @@ public class SettingsCtrl extends AbstractCtrl {
 
 			private double lastSize;
 			private double lastThresh;
+			private double lastThreshZero;
 
 			@Override
 			public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue,
 					Boolean newValue) {
 				ObjectProperty<Double> binSizeProperty = binSizeSpinner.getNumberProperty();
 				ObjectProperty<Double> iThreshProperty = iThreshSpinner.getNumberProperty();
+
 				if (newValue) {
 					lastSize = binSizeProperty.get();
 					binSizeProperty.set(-1.0);
-					lastThresh = iThreshProperty.get();
-					iThreshProperty.set(0.0);
+					iThreshProperty.set(threshBinZero);
 					iThreshSpinner.setDisable(true);
 				} else {
 					binSizeSpinner.setDisable(false);
 					binSizeProperty.set(lastSize);
 					iThreshSpinner.setDisable(false);
-					iThreshProperty.set(lastThresh);
+					iThreshProperty.set(threshBinZero);
 				}
 			}
 		});

--- a/src/main/java/flimlib/flimj/ui/controller/SettingsCtrl.java
+++ b/src/main/java/flimlib/flimj/ui/controller/SettingsCtrl.java
@@ -152,17 +152,24 @@ public class SettingsCtrl extends AbstractCtrl {
 		fullBinningCheckBox.selectedProperty().addListener(new ChangeListener<Boolean>() {
 
 			private double lastSize;
+			private double lastThresh;
 
 			@Override
 			public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue,
 					Boolean newValue) {
 				ObjectProperty<Double> binSizeProperty = binSizeSpinner.getNumberProperty();
+				ObjectProperty<Double> iThreshProperty = iThreshSpinner.getNumberProperty();
 				if (newValue) {
 					lastSize = binSizeProperty.get();
 					binSizeProperty.set(-1.0);
+					lastThresh = iThreshProperty.get();
+					iThreshProperty.set(0.0);
+					iThreshSpinner.setDisable(true);
 				} else {
 					binSizeSpinner.setDisable(false);
 					binSizeProperty.set(lastSize);
+					iThreshSpinner.setDisable(false);
+					iThreshProperty.set(lastThresh);
 				}
 			}
 		});
@@ -364,7 +371,7 @@ public class SettingsCtrl extends AbstractCtrl {
 	/**
 	 * Adjust the parameter pane to make the parameter labels agree with the algorithm and the
 	 * number of components.
-	 * 
+	 *
 	 * @param algo  the algorithm used to perform fitting
 	 * @param nComp the number of components (available only for LMA and global)
 	 */
@@ -454,7 +461,7 @@ public class SettingsCtrl extends AbstractCtrl {
 
 	/**
 	 * Set the parameter labels. Add and remove entries if necessary.
-	 * 
+	 *
 	 * @param paramNames the list of all labels
 	 */
 	private void setParams(List<String> paramNames, List<Boolean> paramIsInputs) {
@@ -478,7 +485,7 @@ public class SettingsCtrl extends AbstractCtrl {
 
 	/**
 	 * Create a parameter entry that includes the label, the input TextField and the "Fix" CheckBox.
-	 * 
+	 *
 	 * @param name     the parameter label
 	 * @param isInput  true if the parameter can have a "Fix" checkbox and mutable value
 	 * @param paramIdx the index in params.param[] or params.paramFree[]

--- a/src/main/java/flimlib/flimj/ui/controller/SettingsCtrl.java
+++ b/src/main/java/flimlib/flimj/ui/controller/SettingsCtrl.java
@@ -160,8 +160,6 @@ public class SettingsCtrl extends AbstractCtrl {
 		fullBinningCheckBox.selectedProperty().addListener(new ChangeListener<Boolean>() {
 
 			private double lastSize;
-			private double lastThresh;
-			private double lastThreshZero;
 
 			@Override
 			public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue,


### PR DESCRIPTION
Changes to `SettingsCtrl.java` so that the behaviour of the `Bin all pixels` checkbox is more similar to that of TRI2. A variable named `threshBinZero` is used to store the threshold level for a bin size of zero and this threshold level (if set) is applied when `Bin all pixels` is checked.

Likewise, when clicking `Bin all pixels` the preview image will be set to that with bin size zero. Unchecking the `Bin all pixels` box will reuse the previously set bin size.