### PR TITLE
Migrate flimj-ui to Java 21 and openjfx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '21'
           java-package: 'jdk+fx'
           distribution: 'zulu'
           cache: 'maven'

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 		<javafx-fxml.version>23.0.1</javafx-fxml.version>
 		<javafx-graphics.version>23.0.2</javafx-graphics.version>
 		<javafx-swing.version>23.0.1</javafx-swing.version>
-		<controlsfx.version>8.40.15</controlsfx.version>
+		<controlsfx.version>11.2.1</controlsfx.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
 			<version>${flimlib.version}</version>
 		</dependency>
 
+		<!-- SCIFIO dependencies -->
+		<dependency>
+			<groupId>io.scif</groupId>
+			<artifactId>scifio</artifactId>
+		</dependency>
+
 		<!-- ImageJ dependencies -->
 		<dependency>
 			<groupId>net.imagej</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,18 @@
 		<license.licenseName>gpl_v3</license.licenseName>
 		<license.copyrightOwners>Board of Regents of the University of Wisconsin-Madison.</license.copyrightOwners>
 
+		<scijava.jvm.version>21</scijava.jvm.version>
+
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
 		<flimlib.version>2.1.1</flimlib.version>
 		<flimj-ops.version>2.1.1</flimj-ops.version>
+		<javafx-base.version>23.0.2</javafx-base.version>
+		<javafx-controls.version>23.0.2</javafx-controls.version>
+		<javafx-fxml.version>23.0.1</javafx-fxml.version>
+		<javafx-graphics.version>23.0.2</javafx-graphics.version>
+		<javafx-swing.version>23.0.1</javafx-swing.version>
 		<controlsfx.version>8.40.15</controlsfx.version>
 	</properties>
 
@@ -135,6 +142,33 @@
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-common</artifactId>
 		</dependency>
+
+		<!-- JavaFX dependencies -->
+	<dependency>
+		<groupId>org.openjfx</groupId>
+		<artifactId>javafx-base</artifactId>
+		<version>${javafx-base.version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.openjfx</groupId>
+		<artifactId>javafx-controls</artifactId>
+		<version>${javafx-controls.version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.openjfx</groupId>
+		<artifactId>javafx-fxml</artifactId>
+		<version>${javafx-fxml.version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.openjfx</groupId>
+		<artifactId>javafx-graphics</artifactId>
+		<version>${javafx-graphics.version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.openjfx</groupId>
+		<artifactId>javafx-swing</artifactId>
+		<version>${javafx-swing.version}</version>
+	</dependency>
 
 		<!-- Other dependencies -->
 		<dependency>

--- a/src/main/java/flimlib/flimj/ui/controller/SettingsCtrl.java
+++ b/src/main/java/flimlib/flimj/ui/controller/SettingsCtrl.java
@@ -206,6 +206,9 @@ public class SettingsCtrl extends AbstractCtrl {
 		noiseChoiceBox.setConverter(new StringConverter<NoiseType>() {
 			@Override
 			public String toString(NoiseType noiseType) {
+				if (noiseType == null) {
+					return "";
+				}
 				switch (noiseType) {
 					case NOISE_GAUSSIAN_FIT:
 						return "Gaussian (Fit)";


### PR DESCRIPTION
This PR updates `flimj-ui` to build on Java 21+ and `openjfx`, making it functional with Fiji Future (the update to Java 21 for Fiji). Unfortunately, `flimj-ui` still relies on javascript to create the plots so for now users will need to activate javascript for javafx like so:

```bash
$ ./fiji-linux-x64 -Djavafx.allowjs=true
```